### PR TITLE
Command history

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ using a keyboard, one can type / edit at the prompt.
 additionally:
 
 - `Enter`: submit prompt to current REPL
+- directional arrows `↑`, `↓`: browse input history
 - `Alt` + directional arrows: scroll UP/DOWN/LEFT/RIGHT
-- standard Unix/Emacs bindings (`Ctrl+A`, `Ctrl+E`, `Ctrl+W`, `Ctrl+K`, `Ctrl+Y`, `Ctrl+L`) work
+- standard Unix/Emacs bindings (`Ctrl+P`, `Ctrl-N`, `Ctrl+A`, `Ctrl+E`, `Ctrl+W`, `Ctrl+K`, `Ctrl+Y`, `Ctrl+L`) work
 
 
 ## implementation details

--- a/lib/repl_ui.lua
+++ b/lib/repl_ui.lua
@@ -50,22 +50,41 @@ end
 -- ------------------------------------------------------------------------
 -- REPL INPUT HISTORY
 
-input_history = {MAIDEN = {hist = {}, offset = 0}, SC = {hist = {}, offset = 0}}
+local input_history = {
+   MAIDEN = {
+      hist = {},
+      offset = 0
+   },
+   SC = {
+      hist = {},
+      offset = 0
+   }
+}
 
 function get_previous_input(repl)
+   if input_history[repl].offset == #input_history[repl].hist then
+      -- Persist the first entry rather than resort to empty line.
+      return input_history[repl].hist[1] or "" -- latter covers the edge case of fresh history
+   end
+   -- FIXME: Figure out index first, only then the message; reason based on index and hist length.
    local prev_input = input_history[repl].hist[#input_history[repl].hist - input_history[repl].offset]
-   if input_history[repl].offset <= #input_history[repl].hist then
+   if input_history[repl].offset < #input_history[repl].hist then
       input_history[repl].offset = input_history[repl].offset + 1
    end
-   return prev_input
+   return prev_input or ""
 end
 
 function get_next_input(repl)
-   local next_input = input_history[repl].hist[#input_history[repl].hist - input_history[repl].offset]
+   -- End of history
+   if input_history[repl].offset == 0 and #input_history[repl].hist then
+      -- return "" -- Provide empty line. Unfortunately loses what was there
+      return prompts[repl].text
+   end
    if input_history[repl].offset > 0 then
       input_history[repl].offset = input_history[repl].offset - 1
    end
-   return next_input or ""
+   local next_input = input_history[repl].hist[#input_history[repl].hist - input_history[repl].offset]
+   return next_input
 end
 
 -- ------------------------------------------------------------------------

--- a/lib/repl_ui.lua
+++ b/lib/repl_ui.lua
@@ -19,7 +19,7 @@ local lines_leading = 6
 -- ------------------------------------------------------------------------
 -- STATE - PROMPTS
 
-prompts = {
+local prompts = {
   MAIDEN={
     text = "",
     kill = "",

--- a/lib/repl_ui.lua
+++ b/lib/repl_ui.lua
@@ -62,26 +62,27 @@ local input_history = {
 }
 
 function get_previous_input(repl)
-  if input_history[repl].offset == #input_history[repl].hist then
-    return input_history[repl].hist[1] or "" -- latter covers the edge case of fresh history
+  if #input_history[repl].hist == 0 then -- history is empty
+    return prompts[repl].text
   end
-  -- FIXME: Figure out index first, only then the message; reason based on index and hist length.
-  local prev_input = input_history[repl].hist[#input_history[repl].hist - input_history[repl].offset]
   if input_history[repl].offset < #input_history[repl].hist then
     input_history[repl].offset = input_history[repl].offset + 1
   end
-  return prev_input or ""
+  local prev_input = input_history[repl].hist[#input_history[repl].hist - input_history[repl].offset + 1]
+  return prev_input
 end
 
+
 function get_next_input(repl)
-  if input_history[repl].offset <= 1 then
-    return prompts[repl].text -- back to the unfinished draft
-  end
-  if input_history[repl].offset > 0 then
+  -- FIXME: an Obi-Wan error somewhere, sometimes first "next" does not scroll the history
+  if input_history[repl].offset > 0 and input_history[repl].offset <= #input_history[repl].hist then
     input_history[repl].offset = input_history[repl].offset - 1
+    local next_input = input_history[repl].hist[#input_history[repl].hist - input_history[repl].offset]
+    return next_input
+  else
+    -- return prompts[repl].text -- FIXME: return what the user was working on rather than blank.
+    return ""
   end
-  local next_input = input_history[repl].hist[#input_history[repl].hist - input_history[repl].offset]
-  return next_input
 end
 
 -- ------------------------------------------------------------------------

--- a/lib/repl_ui.lua
+++ b/lib/repl_ui.lua
@@ -19,16 +19,20 @@ local lines_leading = 6
 -- ------------------------------------------------------------------------
 -- STATE - PROMPTS
 
-local prompts = {
+prompts = {
   MAIDEN={
     text = "",
     kill = "",
+    hist = {},
+    offset = 0,
     cursor = 0,
     submit_fn = repl_osc_gw.send_maiden,
   },
   SC ={
     text = "",
     kill = "",
+    hist = {},
+    offset = 0,
     cursor = 0,
     submit_fn = repl_osc_gw.send_sc,
   },
@@ -50,34 +54,23 @@ end
 -- ------------------------------------------------------------------------
 -- REPL INPUT HISTORY
 
-local input_history = {
-  MAIDEN = {
-    hist = {},
-    offset = 0
-  },
-  SC = {
-    hist = {},
-    offset = 0
-  }
-}
-
 function get_previous_input(repl)
-  if #input_history[repl].hist == 0 then -- history is empty
+  if #prompts[repl].hist == 0 then -- history is empty
     return prompts[repl].text
   end
-  if input_history[repl].offset < #input_history[repl].hist then
-    input_history[repl].offset = input_history[repl].offset + 1
+  if prompts[repl].offset < #prompts[repl].hist then
+    prompts[repl].offset = prompts[repl].offset + 1
   end
-  local prev_input = input_history[repl].hist[#input_history[repl].hist - input_history[repl].offset + 1]
+  local prev_input = prompts[repl].hist[#prompts[repl].hist - prompts[repl].offset + 1]
   return prev_input
 end
 
 
 function get_next_input(repl)
   -- FIXME: an Obi-Wan error somewhere, sometimes first "next" does not scroll the history
-  if input_history[repl].offset > 0 and input_history[repl].offset <= #input_history[repl].hist then
-    input_history[repl].offset = input_history[repl].offset - 1
-    local next_input = input_history[repl].hist[#input_history[repl].hist - input_history[repl].offset]
+  if prompts[repl].offset > 0 and prompts[repl].offset <= #prompts[repl].hist then
+    prompts[repl].offset = prompts[repl].offset - 1
+    local next_input = prompts[repl].hist[#prompts[repl].hist - prompts[repl].offset]
     return next_input
   else
     -- return prompts[repl].text -- FIXME: return what the user was working on rather than blank.
@@ -346,9 +339,9 @@ function repl_ui.kbd_code(repl, code, value)
   elseif code == 'ENTER' and value > 0 then
     -- FIXME: this clause is currently doing too much
     if prompts[repl].text ~= "" then
-      table.insert(input_history[repl].hist, prompts[repl].text)
+      table.insert(prompts[repl].hist, prompts[repl].text)
     end
-    input_history[repl].offset = 0
+    prompts[repl].offset = 0
     prompts[repl].submit_fn(prompts[repl].text)
     prompts[repl].text = ""
     prompts[repl].cursor = 0

--- a/lib/repl_ui.lua
+++ b/lib/repl_ui.lua
@@ -51,37 +51,37 @@ end
 -- REPL INPUT HISTORY
 
 local input_history = {
-   MAIDEN = {
-      hist = {},
-      offset = 0
-   },
-   SC = {
-      hist = {},
-      offset = 0
-   }
+  MAIDEN = {
+    hist = {},
+    offset = 0
+  },
+  SC = {
+    hist = {},
+    offset = 0
+  }
 }
 
 function get_previous_input(repl)
-   if input_history[repl].offset == #input_history[repl].hist then
-      return input_history[repl].hist[1] or "" -- latter covers the edge case of fresh history
-   end
-   -- FIXME: Figure out index first, only then the message; reason based on index and hist length.
-   local prev_input = input_history[repl].hist[#input_history[repl].hist - input_history[repl].offset]
-   if input_history[repl].offset < #input_history[repl].hist then
-      input_history[repl].offset = input_history[repl].offset + 1
-   end
-   return prev_input or ""
+  if input_history[repl].offset == #input_history[repl].hist then
+    return input_history[repl].hist[1] or "" -- latter covers the edge case of fresh history
+  end
+  -- FIXME: Figure out index first, only then the message; reason based on index and hist length.
+  local prev_input = input_history[repl].hist[#input_history[repl].hist - input_history[repl].offset]
+  if input_history[repl].offset < #input_history[repl].hist then
+    input_history[repl].offset = input_history[repl].offset + 1
+  end
+  return prev_input or ""
 end
 
 function get_next_input(repl)
-   if input_history[repl].offset <= 1 then
-      return prompts[repl].text -- back to the unfinished draft
-   end
-   if input_history[repl].offset > 0 then
-      input_history[repl].offset = input_history[repl].offset - 1
-   end
-   local next_input = input_history[repl].hist[#input_history[repl].hist - input_history[repl].offset]
-   return next_input
+  if input_history[repl].offset <= 1 then
+    return prompts[repl].text -- back to the unfinished draft
+  end
+  if input_history[repl].offset > 0 then
+    input_history[repl].offset = input_history[repl].offset - 1
+  end
+  local next_input = input_history[repl].hist[#input_history[repl].hist - input_history[repl].offset]
+  return next_input
 end
 
 -- ------------------------------------------------------------------------
@@ -343,9 +343,9 @@ function repl_ui.kbd_code(repl, code, value)
     local after_cursor = prompt_after_cursor(repl)
     prompts[repl].text = before_cursor .. string.sub(after_cursor, 2)
   elseif code == 'ENTER' and value > 0 then
-     -- FIXME: this clause is currently doing too much
+    -- FIXME: this clause is currently doing too much
     if prompts[repl].text ~= "" then
-       table.insert(input_history[repl].hist, prompts[repl].text)
+      table.insert(input_history[repl].hist, prompts[repl].text)
     end
     input_history[repl].offset = 0
     prompts[repl].submit_fn(prompts[repl].text)
@@ -366,10 +366,16 @@ function repl_ui.kbd_code(repl, code, value)
   elseif code == 'UP' and value > 0 then
     if keyboard.alt() then
       offset_repl_output_up(out_buffs[repl], 1)
+    else
+      prompts[repl].text = get_previous_input(repl)
+      prompts[repl].cursor = string.len(prompts[repl].text)
     end
   elseif code == 'DOWN' and value > 0 then
     if keyboard.alt() then
       offset_repl_output_down(out_buffs[repl], 1)
+    else
+      prompts[repl].text = get_next_input(repl)
+      prompts[repl].cursor = string.len(prompts[repl].text)
     end
   end
 end

--- a/lib/repl_ui.lua
+++ b/lib/repl_ui.lua
@@ -63,7 +63,6 @@ local input_history = {
 
 function get_previous_input(repl)
    if input_history[repl].offset == #input_history[repl].hist then
-      -- Persist the first entry rather than resort to empty line.
       return input_history[repl].hist[1] or "" -- latter covers the edge case of fresh history
    end
    -- FIXME: Figure out index first, only then the message; reason based on index and hist length.
@@ -75,10 +74,8 @@ function get_previous_input(repl)
 end
 
 function get_next_input(repl)
-   -- End of history
-   if input_history[repl].offset == 0 and #input_history[repl].hist then
-      -- return "" -- Provide empty line. Unfortunately loses what was there
-      return prompts[repl].text
+   if input_history[repl].offset <= 1 then
+      return prompts[repl].text -- back to the unfinished draft
    end
    if input_history[repl].offset > 0 then
       input_history[repl].offset = input_history[repl].offset - 1

--- a/lib/repl_ui.lua
+++ b/lib/repl_ui.lua
@@ -4,6 +4,7 @@ local repl_ui = {}
 -- ------------------------------------------------------------------------
 -- DEPS
 
+local tab = require("tabutil")
 local repl_osc_gw = require 'repl/lib/repl_osc_gw'
 local fifo = require 'repl/lib/fifo'
 
@@ -54,23 +55,25 @@ end
 -- ------------------------------------------------------------------------
 -- REPL INPUT HISTORY
 
-function get_previous_input(repl)
-  if #prompts[repl].hist == 0 then -- history is empty
+local function get_previous_input(repl)
+  if tab.count(prompts[repl].hist) == 0 then -- history is empty
     return prompts[repl].text
   end
-  if prompts[repl].offset < #prompts[repl].hist then
+  if prompts[repl].offset < tab.count(prompts[repl].hist) then
     prompts[repl].offset = prompts[repl].offset + 1
+    local prev_input = prompts[repl].hist[tab.count(prompts[repl].hist) - prompts[repl].offset + 1]
+    return prev_input
+  else
+    return prompts[repl].hist[1]
   end
-  local prev_input = prompts[repl].hist[#prompts[repl].hist - prompts[repl].offset + 1]
-  return prev_input
 end
 
-
-function get_next_input(repl)
-  -- FIXME: an Obi-Wan error somewhere, sometimes first "next" does not scroll the history
-  if prompts[repl].offset > 0 and prompts[repl].offset <= #prompts[repl].hist then
+local function get_next_input(repl)
+  if prompts[repl].offset > 0 and prompts[repl].offset <= tab.count(prompts[repl].hist) then
     prompts[repl].offset = prompts[repl].offset - 1
-    local next_input = prompts[repl].hist[#prompts[repl].hist - prompts[repl].offset]
+  end
+  if prompts[repl].offset > 0 then
+    local next_input = prompts[repl].hist[tab.count(prompts[repl].hist) - prompts[repl].offset + 1]
     return next_input
   else
     -- return prompts[repl].text -- FIXME: return what the user was working on rather than blank.

--- a/lib/repl_ui_test.lua
+++ b/lib/repl_ui_test.lua
@@ -9,181 +9,181 @@ require('repl/lib/repl_ui')
 
 -- Mock data
 function have_prompt()
-   prompts = {
-      MAIDEN = {
-         text = ""
-      }
-   }
+  prompts = {
+    MAIDEN = {
+      text = ""
+    }
+  }
 end
 
 function have_history()
-   input_history = {
-      MAIDEN = {
-         hist = {},
-         offset = 0
-      },
-      SC = {
-         hist = {},
-         offset = 0
-      }
-   }
-   table.insert(input_history[repl].hist, "oldest command")
-   table.insert(input_history[repl].hist, "old command")
-   table.insert(input_history[repl].hist, "latest command")
+  input_history = {
+    MAIDEN = {
+      hist = {},
+      offset = 0
+    },
+    SC = {
+      hist = {},
+      offset = 0
+    }
+  }
+  table.insert(input_history[repl].hist, "oldest command")
+  table.insert(input_history[repl].hist, "old command")
+  table.insert(input_history[repl].hist, "latest command")
 end
 
 function have_no_history()
-   input_history = {
-      MAIDEN = {
-         hist = {},
-         offset = 0
-      },
-      SC = {
-         hist = {},
-         offset = 0
-      }
-   }
+  input_history = {
+    MAIDEN = {
+      hist = {},
+      offset = 0
+    },
+    SC = {
+      hist = {},
+      offset = 0
+    }
+  }
 end
-
+
 TestTesting = {}
 function TestTesting:testTesting()
-   luaunit.assertTrue(true)
+  luaunit.assertTrue(true)
 end
 
 function TestTesting:testData()
-   repl = "MAIDEN"
-   have_history()
+  repl = "MAIDEN"
+  have_history()
 
-   luaunit.assertNotNil(input_history)
-   luaunit.assertEquals(#input_history[repl].hist, 3)
+  luaunit.assertNotNil(input_history)
+  luaunit.assertEquals(#input_history[repl].hist, 3)
 end
-
+
 -- class TestInputHistoryBackward <--
 TestInputHistoryBackward = {}
 function TestInputHistoryBackward:setUp()
-   repl = "MAIDEN"
-   have_history()
+  repl = "MAIDEN"
+  have_history()
 end
 
 function TestInputHistoryBackward:testShouldGetPreviousInput()
-   luaunit.assertEquals(get_previous_input(repl), "latest command")
+  luaunit.assertEquals(get_previous_input(repl), "latest command")
 end
 
 function TestInputHistoryBackward:testShouldGetPreviousPreviousInput()
-   get_previous_input(repl)
-   luaunit.assertEquals(get_previous_input(repl), "old command")
+  get_previous_input(repl)
+  luaunit.assertEquals(get_previous_input(repl), "old command")
 end
 
 function TestInputHistoryBackward:testShouldGetOldestInput()
-   get_previous_input(repl)
-   get_previous_input(repl)
-   luaunit.assertEquals(get_previous_input("MAIDEN"), "oldest command")
+  get_previous_input(repl)
+  get_previous_input(repl)
+  luaunit.assertEquals(get_previous_input("MAIDEN"), "oldest command")
 end
 
 function TestInputHistoryBackward:testShouldGetOldestInputForever()
-   get_previous_input(repl)
-   get_previous_input(repl)
-   get_previous_input(repl)
-   luaunit.assertEquals(get_previous_input(repl), "oldest command")
+  get_previous_input(repl)
+  get_previous_input(repl)
+  get_previous_input(repl)
+  luaunit.assertEquals(get_previous_input(repl), "oldest command")
 end
 
 function TestInputHistoryBackward:testShouldGetOldestInputForeverAndEver()
-   get_previous_input(repl)
-   get_previous_input(repl)
-   luaunit.assertEquals(get_previous_input(repl), "oldest command")
-   luaunit.assertEquals(get_previous_input(repl), "oldest command")
-   luaunit.assertEquals(get_previous_input(repl), "oldest command")
+  get_previous_input(repl)
+  get_previous_input(repl)
+  luaunit.assertEquals(get_previous_input(repl), "oldest command")
+  luaunit.assertEquals(get_previous_input(repl), "oldest command")
+  luaunit.assertEquals(get_previous_input(repl), "oldest command")
 end
 -- end of class TestInputHistoryBackward
-
+
 -- class TestInputHistoryBackwardNewSession
 TestInputHistoryBackwardNewSession = {}
 function TestInputHistoryBackwardNewSession:setUp()
-   repl = "MAIDEN"
-   have_no_history()
+  repl = "MAIDEN"
+  have_no_history()
 end
 
 function TestInputHistoryBackwardNewSession:testShouldGetPreviousInput()
-   luaunit.assertEquals(get_previous_input(repl), "")
+  luaunit.assertEquals(get_previous_input(repl), "")
 end
 -- end of class TestInputHistoryBackwardNewSession
-
+
 -- class TestInputHistoryForward
 TestInputHistoryForward = {}
 function TestInputHistoryForward:setUp()
-   repl = "MAIDEN"
-   have_history()
+  repl = "MAIDEN"
+  have_history()
 end
 
 function TestInputHistoryForward:testForwardShouldGetNextInput()
-   get_previous_input(repl)
-   get_previous_input(repl)
-   luaunit.assertEquals(get_next_input(repl), "old command")
+  get_previous_input(repl)
+  get_previous_input(repl)
+  luaunit.assertEquals(get_next_input(repl), "old command")
 end
 
 function TestInputHistoryForward:testForwardShouldReturnToBlankInput()
-   have_prompt()
-   
-   luaunit.assertEquals(get_previous_input(repl), "latest command")
-   -- get_next_input(repl)
-   luaunit.assertEquals(get_next_input(repl), "")
+  have_prompt()
+
+  luaunit.assertEquals(get_previous_input(repl), "latest command")
+  -- get_next_input(repl)
+  luaunit.assertEquals(get_next_input(repl), "")
 end
 
 function TestInputHistoryForward:testForwardAtDraftShouldStayAtDraftInput()
-   have_prompt()
-   prompts[repl].text = "incomplete co"
+  have_prompt()
+  prompts[repl].text = "incomplete co"
 
-   luaunit.assertEquals(get_next_input(repl), "incomplete co")
+  luaunit.assertEquals(get_next_input(repl), "incomplete co")
 end
 
 function TestInputHistoryForward:testForwardFromLastShouldReturnToDraftInput()
-   have_prompt()
-   prompts[repl].text = "incomplete co"
+  have_prompt()
+  prompts[repl].text = "incomplete co"
 
-   luaunit.assertEquals(get_previous_input(repl), "latest command")
-   -- get_next_input(repl)
-   luaunit.assertEquals(get_next_input(repl), "incomplete co")
+  luaunit.assertEquals(get_previous_input(repl), "latest command")
+  -- get_next_input(repl)
+  luaunit.assertEquals(get_next_input(repl), "incomplete co")
 end
 
 function TestInputHistoryForward:testForwardShouldGetLatestInputForever()
-   have_prompt()
-   
-   luaunit.assertEquals(get_previous_input(repl), "latest command")
-   luaunit.assertEquals(get_next_input(repl), "")
+  have_prompt()
+
+  luaunit.assertEquals(get_previous_input(repl), "latest command")
+  luaunit.assertEquals(get_next_input(repl), "")
 end
 
 function TestInputHistoryForward:testForwardShouldStayAtLatestInputForeverAndEver()
-   have_prompt()
+  have_prompt()
 
-   luaunit.assertEquals(get_previous_input(repl), "latest command")
-   luaunit.assertEquals(get_next_input(repl), "")
-   luaunit.assertEquals(get_next_input(repl), "")
-   luaunit.assertEquals(get_next_input(repl), "")
+  luaunit.assertEquals(get_previous_input(repl), "latest command")
+  luaunit.assertEquals(get_next_input(repl), "")
+  luaunit.assertEquals(get_next_input(repl), "")
+  luaunit.assertEquals(get_next_input(repl), "")
 end
 -- end of class TestInputHistoryForward
-
+
 -- class TestInputHistoryForwardNewSession
 TestInputHistoryForwardNewSession = {}
 function TestInputHistoryForwardNewSession:setUp()
-   repl = "MAIDEN"
-   have_no_history()
+  repl = "MAIDEN"
+  have_no_history()
 end
 
 function TestInputHistoryForwardNewSession:testShouldReturnToBlankInput()
-   have_prompt()
+  have_prompt()
 
-   luaunit.assertEquals(get_previous_input(repl), "")
+  luaunit.assertEquals(get_previous_input(repl), "")
 end
 
 function TestInputHistoryForwardNewSession:testShouldReturnToDraftInput()
-   have_prompt()
-   prompts[repl].text = "incomplete co"
+  have_prompt()
+  prompts[repl].text = "incomplete co"
 
-   get_previous_input(repl)
-   get_next_input(repl)
-   luaunit.assertEquals(get_next_input(repl), "incomplete co")
+  get_previous_input(repl)
+  get_next_input(repl)
+  luaunit.assertEquals(get_next_input(repl), "incomplete co")
 end
 -- end of class TestInputHistoryForwardWithoutHistory
-
+
 -- Runner
 os.exit(luaunit.LuaUnit:run())

--- a/lib/repl_ui_test.lua
+++ b/lib/repl_ui_test.lua
@@ -1,11 +1,18 @@
 -- A little test suite for the repl_ui library, starting with the
 -- input history feature.
 --
--- N.b. the `input_histories` as well `prompts` need to temporarily be
+-- Tests run from from project root e.g. dust/code/repl/
+--
+-- FIXME: `prompts` as well as the two target functions
+-- `get_previous_input` and `get_next_input` need to temporarily be
 -- global, rather than local.
 
+package.path = "../../../norns/lua/lib/?;../../../norns/lua/lib/?.lua;"..package.path
+package.path = "../?;../?.lua;"..package.path
+
 luaunit = require('luaunit')
-require('repl/lib/repl_ui')
+tab = require("tabutil")
+require('lib.repl_ui')
 
 -- Mock data
 function have_history()
@@ -21,9 +28,9 @@ function have_history()
       offset = 0
     }
   }
-  table.insert(prompts[repl].hist, "oldest command")
-  table.insert(prompts[repl].hist, "old command")
-  table.insert(prompts[repl].hist, "latest command")
+  table.insert(prompts[repl].hist, "oldest command") -- offset 3
+  table.insert(prompts[repl].hist, "old command")    -- offset 2
+  table.insert(prompts[repl].hist, "latest command") -- offset 1
 end
 
 function have_no_history()
@@ -46,6 +53,11 @@ function TestTesting:testTesting()
   luaunit.assertTrue(true)
 end
 
+function TestTesting:testRequiringTabutilsShouldWork()
+  luaunit.assertNotNil(tab.count)
+  luaunit.assertEquals(tab.count{1,2,3,4,5}, 5)
+end
+
 function TestTesting:testData()
   repl = "MAIDEN"
   have_history()
@@ -54,7 +66,99 @@ function TestTesting:testData()
   luaunit.assertEquals(#prompts[repl].hist, 3)
 end
 
--- class TestInputHistoryBackward <--
+-- class TestHistoryOffset
+TestHistoryOffset = {}
+function TestHistoryOffset:setUp()
+  repl = "MAIDEN"
+  have_history()
+end
+
+function TestHistoryOffset:testNotDoingAnythingShouldBeZero()
+  luaunit.assertEquals(prompts[repl].offset, 0)
+end
+
+function TestHistoryOffset:testMovingBackShouldDecrementByOne()
+  get_previous_input(repl)
+  luaunit.assertEquals(prompts[repl].offset, 1)
+end
+
+function TestHistoryOffset:testMovingBackMultipleTimesShouldDecrementByAsMany()
+  get_previous_input(repl)
+  get_previous_input(repl)
+  luaunit.assertEquals(prompts[repl].offset, 2)
+end
+
+function TestHistoryOffset:testMovingBackMultipleTimesShouldNotExceedHistory()
+  get_previous_input(repl)
+  get_previous_input(repl)
+  get_previous_input(repl)
+  get_previous_input(repl)
+  luaunit.assertEquals(prompts[repl].offset, 3)
+end
+
+function TestHistoryOffset:testMovingForwardOnceShouldNotGetToFuture()
+  get_next_input(repl)
+  luaunit.assertEquals(prompts[repl].offset, 0)
+end
+
+function TestHistoryOffset:testMovingForwardMultipleTimesShouldNotGetToFuture()
+  get_next_input(repl)
+  get_next_input(repl)
+  get_next_input(repl)
+  luaunit.assertEquals(prompts[repl].offset, 0)
+end
+
+function TestHistoryOffset:testMovingBackAndForwardOnceShouldBeWhereStarted()
+  local starting_offset = prompts[repl].offset
+  get_previous_input(repl)
+  get_next_input(repl)
+  luaunit.assertEquals(prompts[repl].offset, starting_offset)
+end
+
+function TestHistoryOffset:testMovingBackTwiceAndForwardTwiceShouldBeWhereStarted()
+  local starting_offset = prompts[repl].offset
+  get_previous_input(repl)
+  get_next_input(repl)
+  get_previous_input(repl)
+  get_next_input(repl)
+  luaunit.assertEquals(prompts[repl].offset, starting_offset)
+end
+
+function TestHistoryOffset:testMovingBackTwiceAndForwardTwiceShouldBeWhereStarted()
+  local starting_offset = prompts[repl].offset
+  get_previous_input(repl)
+  get_previous_input(repl)
+  get_next_input(repl)
+  get_next_input(repl)
+  luaunit.assertEquals(prompts[repl].offset, starting_offset)
+end
+
+function TestHistoryOffset:testMovingBackToBeginningOfHistoryThenForwardShouldGetToNewest()
+  get_previous_input(repl)
+  get_previous_input(repl)
+  get_previous_input(repl)
+  get_next_input(repl)
+  get_next_input(repl)
+  get_next_input(repl)
+  luaunit.assertEquals(prompts[repl].offset, 0)
+end
+
+function TestHistoryOffset:testMovingBackBeyondHistoryThenForwardShouldGetToNewest()
+  local starting_offset = prompts[repl].offset
+  get_previous_input(repl)
+  get_previous_input(repl)
+  get_previous_input(repl)
+  get_previous_input(repl)
+  get_previous_input(repl)
+  get_previous_input(repl)
+  get_next_input(repl)
+  get_next_input(repl)
+  get_next_input(repl)
+  luaunit.assertEquals(prompts[repl].offset, starting_offset)
+end
+-- end of class TestHistoryOffset
+
+-- class TestInputHistoryBackward
 TestInputHistoryBackward = {}
 function TestInputHistoryBackward:setUp()
   repl = "MAIDEN"
@@ -112,9 +216,9 @@ function TestInputHistoryForward:setUp()
 end
 
 function TestInputHistoryForward:testForwardShouldGetNextInput()
-  get_previous_input(repl)
-  get_previous_input(repl)
-  luaunit.assertEquals(get_next_input(repl), "old command")
+  luaunit.assertEquals(get_previous_input(repl), "latest command")
+  luaunit.assertEquals(get_previous_input(repl), "old command")
+  luaunit.assertEquals(get_next_input(repl), "latest command")
 end
 
 function TestInputHistoryForward:testForwardShouldReturnToBlankInput()

--- a/lib/repl_ui_test.lua
+++ b/lib/repl_ui_test.lua
@@ -8,37 +8,33 @@ luaunit = require('luaunit')
 require('repl/lib/repl_ui')
 
 -- Mock data
-function have_prompt()
+function have_history()
   prompts = {
     MAIDEN = {
-      text = ""
-    }
-  }
-end
-
-function have_history()
-  input_history = {
-    MAIDEN = {
+      text = "",
       hist = {},
       offset = 0
     },
     SC = {
+      text = "",
       hist = {},
       offset = 0
     }
   }
-  table.insert(input_history[repl].hist, "oldest command")
-  table.insert(input_history[repl].hist, "old command")
-  table.insert(input_history[repl].hist, "latest command")
+  table.insert(prompts[repl].hist, "oldest command")
+  table.insert(prompts[repl].hist, "old command")
+  table.insert(prompts[repl].hist, "latest command")
 end
 
 function have_no_history()
-  input_history = {
+  prompts = {
     MAIDEN = {
+      text = "",
       hist = {},
       offset = 0
     },
     SC = {
+      text = "",
       hist = {},
       offset = 0
     }
@@ -54,8 +50,8 @@ function TestTesting:testData()
   repl = "MAIDEN"
   have_history()
 
-  luaunit.assertNotNil(input_history)
-  luaunit.assertEquals(#input_history[repl].hist, 3)
+  luaunit.assertNotNil(prompts)
+  luaunit.assertEquals(#prompts[repl].hist, 3)
 end
 
 -- class TestInputHistoryBackward <--
@@ -122,21 +118,17 @@ function TestInputHistoryForward:testForwardShouldGetNextInput()
 end
 
 function TestInputHistoryForward:testForwardShouldReturnToBlankInput()
-  have_prompt()
-
   luaunit.assertEquals(get_previous_input(repl), "latest command")
   luaunit.assertEquals(get_next_input(repl), "")
 end
 
 function TestInputHistoryForward:testForwardAtDraftShouldStayAtDraftInput()
-  have_prompt()
   prompts[repl].text = "incomplete co"
 
   luaunit.assertEquals(get_next_input(repl), "incomplete co")
 end
 
 function TestInputHistoryForward:testForwardFromLastShouldReturnToDraftInput()
-  have_prompt()
   prompts[repl].text = "incomplete co"
 
   luaunit.assertEquals(get_previous_input(repl), "latest command")
@@ -144,15 +136,11 @@ function TestInputHistoryForward:testForwardFromLastShouldReturnToDraftInput()
 end
 
 function TestInputHistoryForward:testForwardShouldGetLatestInputForever()
-  have_prompt()
-
   luaunit.assertEquals(get_previous_input(repl), "latest command")
   luaunit.assertEquals(get_next_input(repl), "")
 end
 
 function TestInputHistoryForward:testForwardShouldStayAtLatestInputForeverAndEver()
-  have_prompt()
-
   luaunit.assertEquals(get_previous_input(repl), "latest command")
   luaunit.assertEquals(get_next_input(repl), "")
   luaunit.assertEquals(get_next_input(repl), "")
@@ -168,13 +156,10 @@ function TestInputHistoryForwardNewSession:setUp()
 end
 
 function TestInputHistoryForwardNewSession:testShouldReturnToBlankInput()
-  have_prompt()
-
   luaunit.assertEquals(get_previous_input(repl), "")
 end
 
 function TestInputHistoryForwardNewSession:testShouldReturnToDraftInput()
-  have_prompt()
   prompts[repl].text = "incomplete co"
 
   get_previous_input(repl)

--- a/lib/repl_ui_test.lua
+++ b/lib/repl_ui_test.lua
@@ -77,7 +77,7 @@ end
 function TestInputHistoryBackward:testShouldGetOldestInput()
   get_previous_input(repl)
   get_previous_input(repl)
-  luaunit.assertEquals(get_previous_input("MAIDEN"), "oldest command")
+  luaunit.assertEquals(get_previous_input(repl), "oldest command")
 end
 
 function TestInputHistoryBackward:testShouldGetOldestInputForever()
@@ -125,7 +125,6 @@ function TestInputHistoryForward:testForwardShouldReturnToBlankInput()
   have_prompt()
 
   luaunit.assertEquals(get_previous_input(repl), "latest command")
-  -- get_next_input(repl)
   luaunit.assertEquals(get_next_input(repl), "")
 end
 
@@ -141,7 +140,6 @@ function TestInputHistoryForward:testForwardFromLastShouldReturnToDraftInput()
   prompts[repl].text = "incomplete co"
 
   luaunit.assertEquals(get_previous_input(repl), "latest command")
-  -- get_next_input(repl)
   luaunit.assertEquals(get_next_input(repl), "incomplete co")
 end
 

--- a/lib/repl_ui_test.lua
+++ b/lib/repl_ui_test.lua
@@ -1,0 +1,189 @@
+-- A little test suite for the repl_ui library, starting with the
+-- input history feature.
+--
+-- N.b. the `input_histories` as well `prompts` need to temporarily be
+-- global, rather than local.
+
+luaunit = require('luaunit')
+require('repl/lib/repl_ui')
+
+-- Mock data
+function have_prompt()
+   prompts = {
+      MAIDEN = {
+         text = ""
+      }
+   }
+end
+
+function have_history()
+   input_history = {
+      MAIDEN = {
+         hist = {},
+         offset = 0
+      },
+      SC = {
+         hist = {},
+         offset = 0
+      }
+   }
+   table.insert(input_history[repl].hist, "oldest command")
+   table.insert(input_history[repl].hist, "old command")
+   table.insert(input_history[repl].hist, "latest command")
+end
+
+function have_no_history()
+   input_history = {
+      MAIDEN = {
+         hist = {},
+         offset = 0
+      },
+      SC = {
+         hist = {},
+         offset = 0
+      }
+   }
+end
+
+TestTesting = {}
+function TestTesting:testTesting()
+   luaunit.assertTrue(true)
+end
+
+function TestTesting:testData()
+   repl = "MAIDEN"
+   have_history()
+
+   luaunit.assertNotNil(input_history)
+   luaunit.assertEquals(#input_history[repl].hist, 3)
+end
+
+-- class TestInputHistoryBackward <--
+TestInputHistoryBackward = {}
+function TestInputHistoryBackward:setUp()
+   repl = "MAIDEN"
+   have_history()
+end
+
+function TestInputHistoryBackward:testShouldGetPreviousInput()
+   luaunit.assertEquals(get_previous_input(repl), "latest command")
+end
+
+function TestInputHistoryBackward:testShouldGetPreviousPreviousInput()
+   get_previous_input(repl)
+   luaunit.assertEquals(get_previous_input(repl), "old command")
+end
+
+function TestInputHistoryBackward:testShouldGetOldestInput()
+   get_previous_input(repl)
+   get_previous_input(repl)
+   luaunit.assertEquals(get_previous_input("MAIDEN"), "oldest command")
+end
+
+function TestInputHistoryBackward:testShouldGetOldestInputForever()
+   get_previous_input(repl)
+   get_previous_input(repl)
+   get_previous_input(repl)
+   luaunit.assertEquals(get_previous_input(repl), "oldest command")
+end
+
+function TestInputHistoryBackward:testShouldGetOldestInputForeverAndEver()
+   get_previous_input(repl)
+   get_previous_input(repl)
+   luaunit.assertEquals(get_previous_input(repl), "oldest command")
+   luaunit.assertEquals(get_previous_input(repl), "oldest command")
+   luaunit.assertEquals(get_previous_input(repl), "oldest command")
+end
+-- end of class TestInputHistoryBackward
+
+-- class TestInputHistoryBackwardNewSession
+TestInputHistoryBackwardNewSession = {}
+function TestInputHistoryBackwardNewSession:setUp()
+   repl = "MAIDEN"
+   have_no_history()
+end
+
+function TestInputHistoryBackwardNewSession:testShouldGetPreviousInput()
+   luaunit.assertEquals(get_previous_input(repl), "")
+end
+-- end of class TestInputHistoryBackwardNewSession
+
+-- class TestInputHistoryForward
+TestInputHistoryForward = {}
+function TestInputHistoryForward:setUp()
+   repl = "MAIDEN"
+   have_history()
+end
+
+function TestInputHistoryForward:testForwardShouldGetNextInput()
+   get_previous_input(repl)
+   get_previous_input(repl)
+   luaunit.assertEquals(get_next_input(repl), "old command")
+end
+
+function TestInputHistoryForward:testForwardShouldReturnToBlankInput()
+   have_prompt()
+   
+   luaunit.assertEquals(get_previous_input(repl), "latest command")
+   -- get_next_input(repl)
+   luaunit.assertEquals(get_next_input(repl), "")
+end
+
+function TestInputHistoryForward:testForwardAtDraftShouldStayAtDraftInput()
+   have_prompt()
+   prompts[repl].text = "incomplete co"
+
+   luaunit.assertEquals(get_next_input(repl), "incomplete co")
+end
+
+function TestInputHistoryForward:testForwardFromLastShouldReturnToDraftInput()
+   have_prompt()
+   prompts[repl].text = "incomplete co"
+
+   luaunit.assertEquals(get_previous_input(repl), "latest command")
+   -- get_next_input(repl)
+   luaunit.assertEquals(get_next_input(repl), "incomplete co")
+end
+
+function TestInputHistoryForward:testForwardShouldGetLatestInputForever()
+   have_prompt()
+   
+   luaunit.assertEquals(get_previous_input(repl), "latest command")
+   luaunit.assertEquals(get_next_input(repl), "")
+end
+
+function TestInputHistoryForward:testForwardShouldStayAtLatestInputForeverAndEver()
+   have_prompt()
+
+   luaunit.assertEquals(get_previous_input(repl), "latest command")
+   luaunit.assertEquals(get_next_input(repl), "")
+   luaunit.assertEquals(get_next_input(repl), "")
+   luaunit.assertEquals(get_next_input(repl), "")
+end
+-- end of class TestInputHistoryForward
+
+-- class TestInputHistoryForwardNewSession
+TestInputHistoryForwardNewSession = {}
+function TestInputHistoryForwardNewSession:setUp()
+   repl = "MAIDEN"
+   have_no_history()
+end
+
+function TestInputHistoryForwardNewSession:testShouldReturnToBlankInput()
+   have_prompt()
+
+   luaunit.assertEquals(get_previous_input(repl), "")
+end
+
+function TestInputHistoryForwardNewSession:testShouldReturnToDraftInput()
+   have_prompt()
+   prompts[repl].text = "incomplete co"
+
+   get_previous_input(repl)
+   get_next_input(repl)
+   luaunit.assertEquals(get_next_input(repl), "incomplete co")
+end
+-- end of class TestInputHistoryForwardWithoutHistory
+
+-- Runner
+os.exit(luaunit.LuaUnit:run())

--- a/repl.lua
+++ b/repl.lua
@@ -14,6 +14,8 @@
 -- keyboard:
 -- - Enter: submit prompt
 -- - Alt + arrows: scroll
+-- - Ctrl+P: previous input
+-- - Ctrl+N: next input
 -- - Ctrl+A: begining of line
 -- - Ctrl+E: end of line
 -- - Ctrl+W: kill before (cut)


### PR DESCRIPTION
Hi, `repl` is such a fun contraption, esp. as a mod to livecode with. I made a little command history, maybe it is useful for merging? Resolves #1 

Please let me know if it would be better if I implemented this in some other way.

There is still an [Obi-Wan bug](http://www.catb.org/jargon/html/O/obi-wan-error.html) in `get_next_input` as the first time doesn't register somehow, it seems to be about the offset manipulation... I'll see if I can find it. That's why some of the tests fail too (the tests need `prompts` and `input_history` to be temporarily set to be to global, and it needs to be run from `dust/code` to get dependincies).

Another think I would not hesitate to call a UI bug is that if the user/artist has started writing a command, it will be lost if they browse the input history... sadface. This draft should be captured somewhere and returned to. Shouldn't be too hard for me to implement.